### PR TITLE
bug fix: add a hash string to avoid two exp use the same config files

### DIFF
--- a/src/Executables/voxcraft-sim.cpp
+++ b/src/Executables/voxcraft-sim.cpp
@@ -106,8 +106,9 @@ int main(int argc, char** argv) {
                 tree.add("vxd.f", file.path().filename().string());
         }
         std::string str_time = ctool::u_format_now("%Y%m%d%H%M%S");
-        std::string vxt = str_time + ".vxt";
-        std::string vxr = str_time + ".vxr";
+        std::string str_hash_number = std::to_string(std::hash<std::string>{}( input.string() ));
+        std::string vxt = str_time + "." + str_hash_number + ".vxt";
+        std::string vxr = str_time + "." + str_hash_number + ".vxr";
         pt::write_xml((locally/vxt).string(), tree);
         std::string command = str_worker + " -i " + (locally/vxt).string() + " -o " + (locally/vxr).string();
 


### PR DESCRIPTION
a hot-fix for issue #46 