### PR TITLE
increases cudaLimitPrintfFifoSize 50 times from default

### DIFF
--- a/src/Utils/VX3.cuh
+++ b/src/Utils/VX3.cuh
@@ -58,6 +58,7 @@ __device__ __inline__ int random(int max, int random_seed=0) {
     #define CUDA_ERROR_CHECK(ans) { CUDA_ERROR_CHECK_OUTPUT((ans), __FILE__, __LINE__); }
 #endif
 #define VcudaMemGetInfo(a,b) {CUDA_ERROR_CHECK(cudaMemGetInfo(a,b))}
+#define VcudaDeviceGetLimit(a,b) {CUDA_ERROR_CHECK(cudaDeviceGetLimit(a,b))}
 #define VcudaDeviceSetLimit(a,b) {CUDA_ERROR_CHECK(cudaDeviceSetLimit(a,b))}
 #define VcudaSetDevice(a) {CUDA_ERROR_CHECK(cudaSetDevice(a))}
 #define VcudaGetDeviceCount(a) {CUDA_ERROR_CHECK(cudaGetDeviceCount(a))}

--- a/src/VX3/VX3_SimulationManager.cu
+++ b/src/VX3/VX3_SimulationManager.cu
@@ -373,6 +373,7 @@ void VX3_SimulationManager::readVXD(fs::path base, std::vector<fs::path> files, 
         if (HeapSize < 0.01) {
             HeapSize = 0.01;
         }
+        PrintfFIFOSize = pt_merged.get<double>("VXA.GPU.PrintfFIFOSize", 50);
 
         VcudaMemcpy(d_voxelyze_3s[device_index] + i, &h_d_tmp, sizeof(VX3_VoxelyzeKernel), cudaMemcpyHostToDevice);
         i++;
@@ -395,13 +396,13 @@ void VX3_SimulationManager::enlargeGPUHeapSize() {
     // VcudaDeviceSetLimit(cudaLimitStackSize, 2048);
 }
 
-/* gets the current printfFifo buffer size and increases it 50 times */                                                           
+/* gets the current printfFifo buffer size and increases it PrintfFIFOSize times */                                                           
 void VX3_SimulationManager::enlargeGPUPrintfFIFOSize()                                                             
 {                                                               
-    size_t size;               
-    VcudaDeviceGetLimit(&size, cudaLimitPrintfFifoSize);     
-    VcudaDeviceSetLimit(cudaLimitPrintfFifoSize, size*50);
-    printf("set GPU printfFIFO size to be %ld bytes.\n", size*50);
+    size_t PrintfFIFOSizeInBytes;               
+    VcudaDeviceGetLimit(&PrintfFIFOSizeInBytes, cudaLimitPrintfFifoSize);
+    VcudaDeviceSetLimit(cudaLimitPrintfFifoSize, PrintfFIFOSizeInBytes*PrintfFIFOSize);
+    printf("set GPU printfFIFO size to be %ld bytes.\n", PrintfFIFOSizeInBytes*PrintfFIFOSize);
 }
 
 

--- a/src/VX3/VX3_SimulationManager.cu
+++ b/src/VX3/VX3_SimulationManager.cu
@@ -395,6 +395,16 @@ void VX3_SimulationManager::enlargeGPUHeapSize() {
     // VcudaDeviceSetLimit(cudaLimitStackSize, 2048);
 }
 
+/* gets the current printfFifo buffer size and increases it 50 times */                                                           
+void VX3_SimulationManager::enlargeGPUPrintfFIFOSize()                                                             
+{                                                               
+    size_t size;               
+    VcudaDeviceGetLimit(&size, cudaLimitPrintfFifoSize);     
+    VcudaDeviceSetLimit(cudaLimitPrintfFifoSize, size*50);
+    printf("set GPU printfFIFO size to be %ld bytes.\n", size*50);
+}
+
+
 void VX3_SimulationManager::startKernel(int num_simulation, int device_index) {
     int threadsPerBlock = 512;
     int numBlocks = (num_simulation + threadsPerBlock - 1) / threadsPerBlock;
@@ -409,6 +419,7 @@ void VX3_SimulationManager::startKernel(int num_simulation, int device_index) {
     //             num_simulation * sizeof(VX3_VoxelyzeKernel),
     //             cudaMemcpyDeviceToHost);
     enlargeGPUHeapSize();
+    enlargeGPUPrintfFIFOSize();
     CUDA_Simulation<<<numBlocks, threadsPerBlock>>>(d_voxelyze_3s[device_index], num_simulation, device_index);
     CUDA_CHECK_AFTER_CALL();
 }

--- a/src/VX3/VX3_SimulationManager.cuh
+++ b/src/VX3/VX3_SimulationManager.cuh
@@ -44,6 +44,7 @@ class VX3_SimulationManager {
     std::vector<VX3_SimulationResult> h_results;
 
     double HeapSize=1;
+    int PrintfFIFOSize=50;
 };
 
 #endif // VX3_SIMULATION_MANAGER

--- a/src/VX3/VX3_SimulationManager.cuh
+++ b/src/VX3/VX3_SimulationManager.cuh
@@ -25,6 +25,7 @@ class VX3_SimulationManager {
     void collectResults(int num_simulation, int device_index);
     void sortResults();
     void enlargeGPUHeapSize();
+    void enlargeGPUPrintfFIFOSize();
     void ParseMathTree(VX3_MathTreeToken *field_ptr, size_t max_length, std::string node_address, pt::ptree &tree);
 
     /* DATA */


### PR DESCRIPTION
the print calls from device are stored in a circular buffer before being flushed. when the amount of content exceeds the limit of the buffer, it starts overwriting the oldest content. to work around that, this commit does the following:
- adds a new method to get device limit
- uses that method to get the current printfFifoSize and increases it 50 times (mimicks enlargeGPUHeapSize)

I believe this can solve the issue in most cases, but still is probably not the best way to do it. let me know if you prefer a different way (take the new size as a command line parameter, have a fixed size for the buffer, etc)